### PR TITLE
feat(disciplina): Implementa endpoints para detalhe e download

### DIFF
--- a/src/main/java/com/pdfocus/application/material/port/entrada/DownloadMaterialUseCase.java
+++ b/src/main/java/com/pdfocus/application/material/port/entrada/DownloadMaterialUseCase.java
@@ -1,0 +1,29 @@
+package com.pdfocus.application.material.port.entrada;
+
+import com.pdfocus.core.models.Material;
+import org.springframework.core.io.Resource;
+
+import java.util.UUID;
+
+/**
+ * Define o contrato (Porta de Entrada) para o caso de uso de download
+ * de um arquivo de material, garantindo que ele pertença ao
+ * usuário autenticado.
+ */
+public interface DownloadMaterialUseCase {
+
+    /**
+     * DTO interno para agrupar o resultado da operação de download,
+     * contendo o recurso (o arquivo) e os seus metadados.
+     */
+    record DownloadResult(Resource resource, Material material) {}
+
+    /**
+     * Executa a lógica de negócio para localizar e preparar um material para download.
+     * A segurança é garantida pela implementação, que filtra pelo usuário logado.
+     *
+     * @param id O UUID do material a ser baixado.
+     * @return um objeto {@link DownloadResult} contendo o arquivo e seus metadados.
+     */
+    DownloadResult executar(UUID id);
+}

--- a/src/main/java/com/pdfocus/application/material/port/saida/MaterialStoragePort.java
+++ b/src/main/java/com/pdfocus/application/material/port/saida/MaterialStoragePort.java
@@ -1,32 +1,34 @@
 package com.pdfocus.application.material.port.saida;
 
+import org.springframework.core.io.Resource;
 import java.io.InputStream;
 
 /**
- * Porta de Saída (Interface de Storage) para operações de armazenamento físico de ficheiros.
- * <p>
- * Define o contrato que a camada de aplicação usa para interagir com a
- * camada de infraestrutura para guardar, recuperar ou apagar ficheiros fisicamente.
- * </p>
+ * Define o contrato (Porta de Saída) para o sistema de armazenamento físico de ficheiros.
+ * Esta interface abstrai a forma como os ficheiros são guardados (localmente, na nuvem, etc.).
  */
 public interface MaterialStoragePort {
 
     /**
-     * Guarda o conteúdo de um ficheiro num sistema de armazenamento.
+     * Guarda o conteúdo de um InputStream no sistema de armazenamento.
      *
-     * @param nomeFicheiroStorage O nome único gerado para o ficheiro no armazenamento (ex: um UUID com a extensão).
-     * @param inputStream O fluxo de bytes (conteúdo) do ficheiro a ser guardado.
-     * @return Uma string representando a localização ou identificador do ficheiro guardado (ex: o caminho completo ou URL).
+     * @param nomeFicheiro O nome único sob o qual o ficheiro será guardado.
+     * @param inputStream O fluxo de dados do ficheiro a ser guardado.
      */
-    String guardar(String nomeFicheiroStorage, InputStream inputStream);
+    void guardar(String nomeFicheiro, InputStream inputStream);
 
     /**
-     * Apaga um ficheiro físico do sistema de armazenamento.
+     * Apaga um ficheiro do sistema de armazenamento.
      *
-     * @param nomeFicheiroStorage O nome único do ficheiro a ser apagado.
+     * @param nomeFicheiro O nome único do ficheiro a ser apagado.
      */
-    void apagar(String nomeFicheiroStorage);
+    void apagar(String nomeFicheiro);
 
-    // Futuramente, poderíamos adicionar um método para recuperar o ficheiro:
-    // InputStream carregar(String nomeFicheiroStorage);
+    /**
+     * Carrega um ficheiro do sistema de armazenamento como um recurso (Resource).
+     *
+     * @param nomeFicheiro O nome único do ficheiro a ser carregado.
+     * @return um objeto Resource que representa o ficheiro.
+     */
+    Resource carregar(String nomeFicheiro);
 }

--- a/src/main/java/com/pdfocus/application/material/service/DefaultDownloadMaterialService.java
+++ b/src/main/java/com/pdfocus/application/material/service/DefaultDownloadMaterialService.java
@@ -1,0 +1,58 @@
+package com.pdfocus.application.material.service;
+
+import com.pdfocus.application.material.port.entrada.DownloadMaterialUseCase;
+import com.pdfocus.application.material.port.saida.MaterialRepository;
+import com.pdfocus.application.material.port.saida.MaterialStoragePort;
+import com.pdfocus.application.usuario.port.saida.UsuarioRepository;
+import com.pdfocus.core.exceptions.MaterialNaoEncontradoException;
+import com.pdfocus.core.models.Material;
+import com.pdfocus.core.models.Usuario;
+import org.springframework.core.io.Resource;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * Implementação do caso de uso para download de um arquivo de material.
+ * Orquestra a validação de segurança e o acesso ao sistema de arquivos.
+ */
+@Service
+public class DefaultDownloadMaterialService implements DownloadMaterialUseCase {
+
+    private final MaterialRepository materialRepository;
+    private final UsuarioRepository usuarioRepository;
+    private final MaterialStoragePort materialStoragePort;
+
+    public DefaultDownloadMaterialService(MaterialRepository materialRepository,
+                                          UsuarioRepository usuarioRepository,
+                                          MaterialStoragePort materialStoragePort) {
+        this.materialRepository = materialRepository;
+        this.usuarioRepository = usuarioRepository;
+        this.materialStoragePort = materialStoragePort;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public DownloadResult executar(UUID id) {
+        // 1. Identifica o usuário logado a partir do contexto de segurança.
+        String email = ((UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getUsername();
+        Usuario usuario = usuarioRepository.buscarPorEmail(email)
+                .orElseThrow(() -> new IllegalStateException("Usuário autenticado não pôde ser encontrado."));
+
+        // 2. Busca os metadados do material, garantindo que ele pertence ao usuário.
+        Material material = materialRepository.buscarPorIdEUsuario(id, usuario.getId())
+                .orElseThrow(() -> new MaterialNaoEncontradoException(id));
+
+        // 3. Usa a porta de armazenamento para carregar o recurso (arquivo) físico.
+        Resource resource = materialStoragePort.carregar(material.getNomeStorage());
+
+        // 4. Retorna o "pacote" completo com o arquivo e seus metadados.
+        return new DownloadResult(resource, material);
+    }
+}

--- a/src/main/java/com/pdfocus/infra/storage/adapter/LocalFileStorageAdapter.java
+++ b/src/main/java/com/pdfocus/infra/storage/adapter/LocalFileStorageAdapter.java
@@ -2,10 +2,13 @@ package com.pdfocus.infra.storage.adapter;
 
 import com.pdfocus.application.material.port.saida.MaterialStoragePort;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -18,45 +21,66 @@ import java.nio.file.StandardCopyOption;
 @Component
 public class LocalFileStorageAdapter implements MaterialStoragePort {
 
+    private final Path rootLocation;
+
     /**
-     * Injeta o caminho do diretório de armazenamento a partir do application.properties.
+     * Constrói o adaptador. O caminho do diretório de uploads é injetado
+     * a partir do ficheiro application.properties via anotação @Value.
+     *
+     * @param storageDirectory O caminho para o diretório de uploads (ex: "uploads").
      */
-    @Value("${storage.local.directory}")
-    private String diretorioStorage;
+    public LocalFileStorageAdapter(@Value("${storage.local.directory}") String storageDirectory) {
+        this.rootLocation = Paths.get(storageDirectory);
+        try {
+            Files.createDirectories(rootLocation);
+        } catch (IOException e) {
+            throw new RuntimeException("Não foi possível inicializar o diretório de armazenamento.", e);
+        }
+    }
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Esta implementação guarda o ficheiro numa pasta no sistema de ficheiros local.
-     * </p>
      */
     @Override
-    public String guardar(String nomeFicheiroStorage, InputStream inputStream) {
+    public void guardar(String nomeFicheiroStorage, InputStream inputStream) {
         try {
-            Path diretorioPath = Paths.get(diretorioStorage);
-            Files.createDirectories(diretorioPath);
-            Path destinoPath = diretorioPath.resolve(nomeFicheiroStorage);
+            Path destinoPath = this.rootLocation.resolve(nomeFicheiroStorage);
             Files.copy(inputStream, destinoPath, StandardCopyOption.REPLACE_EXISTING);
-            return destinoPath.toAbsolutePath().toString();
         } catch (IOException e) {
-            // Em caso de erro, lança uma exceção.
             throw new RuntimeException("Falha ao guardar o ficheiro: " + nomeFicheiroStorage, e);
         }
     }
 
     /**
      * {@inheritDoc}
-     * <p>
-     * Esta implementação apaga o ficheiro do sistema de ficheiros local.
-     * </p>
      */
     @Override
     public void apagar(String nomeFicheiroStorage) {
         try {
-            Path ficheiroPath = Paths.get(diretorioStorage).resolve(nomeFicheiroStorage);
+            Path ficheiroPath = this.rootLocation.resolve(nomeFicheiroStorage);
             Files.deleteIfExists(ficheiroPath);
         } catch (IOException e) {
             throw new RuntimeException("Falha ao apagar o ficheiro: " + nomeFicheiroStorage, e);
         }
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Resource carregar(String nomeFicheiro) {
+        try {
+            Path file = this.rootLocation.resolve(nomeFicheiro);
+            Resource resource = new UrlResource(file.toUri());
+
+            if (resource.exists() && resource.isReadable()) {
+                return resource;
+            } else {
+                throw new RuntimeException("Não foi possível ler o ficheiro: " + nomeFicheiro);
+            }
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Erro ao formar a URL para o ficheiro: " + nomeFicheiro, e);
+        }
+    }
 }
+


### PR DESCRIPTION
## O que este PR faz?

Este PR implementa duas funcionalidades de backend cruciais que formam o coração da página de "Detalhe da Disciplina":

1.  **Visão Detalhada Completa:** O endpoint `GET /disciplinas/{id}` foi refatorado para retornar um "dossier completo" de uma disciplina, incluindo as listas de todos os seus resumos e materiais associados.
2.  **Download Seguro de Materiais:** Foi criado um novo endpoint, `GET /materiais/{id}/download`, que permite ao usuário baixar um arquivo de material. A implementação garante, através do token JWT, que um usuário só possa baixar os materiais que lhe pertencem.

Estas alterações preparam o terreno para que o front-end possa substituir os dados de exemplo por dados reais e dinâmicos.

## Como Testar Manualmente

1.  Execute o backend a partir desta branch.
2.  Use o Postman para obter um **token JWT** válido.
3.  Use este token como **Bearer Token** nas requisições seguintes.

**Cenário de Teste 1: Visão Detalhada**
-   Faça uma requisição `GET` para `http://localhost:8080/disciplinas/{id_de_uma_disciplina}`.
-   **Resultado Esperado:** Um status `200 OK` e um JSON contendo a disciplina e as listas `resumos` e `materiais`.

**Cenário de Teste 2: Download**
-   Pegue o `id` de um material da resposta anterior.
-   Faça uma requisição `GET` para `http://localhost:8080/materiais/{id_do_material}/download`.
-   **Resultado Esperado:** Um status `200 OK`. Use a função "Save Response to a file" do Postman para salvar o arquivo e confirme que ele abre corretamente.